### PR TITLE
Fix Cors Authorization header

### DIFF
--- a/comptoir-ws/src/main/java/be/valuya/comptoir/ws/rest/filter/CrossOriginResourceSharingFilter.java
+++ b/comptoir-ws/src/main/java/be/valuya/comptoir/ws/rest/filter/CrossOriginResourceSharingFilter.java
@@ -19,7 +19,7 @@ public class CrossOriginResourceSharingFilter implements ContainerResponseFilter
         MultivaluedMap<String, Object> headerMap = response.getHeaders();
         headerMap.putSingle("Access-Control-Allow-Origin", "*");
         headerMap.putSingle("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PUT, DELETE");
-        headerMap.putSingle("Access-Control-Allow-Headers", "content-type, accept, accept-charset, authorisation");
+        headerMap.putSingle("Access-Control-Allow-Headers", "content-type, accept, accept-charset, authorization");
         headerMap.putSingle("Access-Control-Expose-Headers", HeadersConfig.LIST_RESULTS_COUNT_HEADER);
     }
     


### PR DESCRIPTION
Le client a été mis à jour égalementLe client a été mis à jour.

J'ai pas trouvé d'endroit où la valeur du header Authorization était utilisée. Si j'ai raté quelque chose, il faudra sans douter aussi le changer.