### PR TITLE
Introduce Arquillian test environment

### DIFF
--- a/comptoir-ejb/arquillian.xml
+++ b/comptoir-ejb/arquillian.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="glassfish" default="true">
+        <configuration>
+            <property name="glassFishHome">${test.glassfish.home}</property>
+            <property name="adminHost">${test.glassfish.host}</property>
+            <property name="adminPort">${test.glassfish.adminPort}</property>
+            <property name="adminUser">${test.glassfish.user}</property>
+            <property name="adminPassword">${test.glassfish.password}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/comptoir-ejb/pom.xml
+++ b/comptoir-ejb/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>be.valuya.comptoir</groupId>
@@ -49,27 +50,139 @@
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.12.1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <profile>
+            <id>test</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>test</value>
+                </property>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jboss.arquillian</groupId>
+                        <artifactId>arquillian-bom</artifactId>
+                        <version>1.1.11.Final</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec</groupId>
+                    <artifactId>jboss-javaee-7.0</artifactId>
+                    <version>1.0.0.Final</version>
+                    <type>pom</type>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.junit</groupId>
+                    <artifactId>arquillian-junit-container</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-embedded</artifactId>
+                    <version>8.1.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-embedded</artifactId>
+                    <version>8.1.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                    <version>1.6.4</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                    <version>10.12.1.1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jooq</groupId>
+                    <artifactId>jooq</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>2.8</version>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>8.1.0.Final</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>target</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.17</version>
+                        <configuration>
+                            <!-- Fork every test because it will launch a separate AS instance -->
+                            <forkMode>always</forkMode>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <!-- the maven dependency plugin will have already downloaded the server on /target -->
+                                <jboss.home>${project.basedir}/target/wildfly-8.1.0.Final</jboss.home>
+                                <module.path>${project.basedir}/target/wildfly-8.1.0.Final/modules</module.path>
+                            </systemPropertyVariables>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 
     <build>
         <plugins>
@@ -135,7 +248,7 @@
                                     <name>BIGINT</name>
                                     <expression>.*\.ID_.*</expression>
                                 </forcedType>
-                            </forcedTypes>           
+                            </forcedTypes>
                             <unsignedTypes>false</unsignedTypes>
                         </database>
                         <target>
@@ -144,6 +257,10 @@
                         </target>
                     </generator>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.17</version>
             </plugin>
         </plugins>
         <testResources>

--- a/comptoir-ejb/pom.xml
+++ b/comptoir-ejb/pom.xml
@@ -108,20 +108,8 @@
                     <version>8.1.0.Final</version>
                 </dependency>
                 <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                    <version>1.6.4</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.derby</groupId>
-                    <artifactId>derby</artifactId>
-                    <version>10.12.1.1</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/comptoir-ejb/pom.xml
+++ b/comptoir-ejb/pom.xml
@@ -15,6 +15,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <db.napo.driver></db.napo.driver>
+        <db.napo.url></db.napo.url>
+        <db.napo.username></db.napo.username>
+        <db.napo.password></db.napo.password>
     </properties>
 
     <dependencies>
@@ -57,6 +61,7 @@
         </dependency>
     </dependencies>
 
+
     <profiles>
         <profile>
             <id>default</id>
@@ -73,6 +78,13 @@
                     <value>test</value>
                 </property>
             </activation>
+            <properties>
+                <test.glassfish.home></test.glassfish.home>
+                <test.glassfish.host></test.glassfish.host>
+                <test.glassfish.adminPort></test.glassfish.adminPort>
+                <test.glassfish.user></test.glassfish.user>
+                <test.glassfish.password></test.glassfish.password>
+            </properties>
             <dependencyManagement>
                 <dependencies>
                     <dependency>
@@ -98,14 +110,10 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-embedded</artifactId>
-                    <version>8.1.0.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-embedded</artifactId>
-                    <version>8.1.0.Final</version>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-managed-3.1</artifactId>
+                    <version>1.0.0.CR4</version>
+                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>junit</groupId>
@@ -122,52 +130,6 @@
                     <artifactId>jooq</artifactId>
                 </dependency>
             </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>2.8</version>
-                        <executions>
-                            <execution>
-                                <id>unpack</id>
-                                <phase>process-test-classes</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.wildfly</groupId>
-                                            <artifactId>wildfly-dist</artifactId>
-                                            <version>8.1.0.Final</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>target</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.17</version>
-                        <configuration>
-                            <!-- Fork every test because it will launch a separate AS instance -->
-                            <forkMode>always</forkMode>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <!-- the maven dependency plugin will have already downloaded the server on /target -->
-                                <jboss.home>${project.basedir}/target/wildfly-8.1.0.Final</jboss.home>
-                                <module.path>${project.basedir}/target/wildfly-8.1.0.Final/modules</module.path>
-                            </systemPropertyVariables>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 
@@ -255,6 +217,9 @@
             <testResource>
                 <directory>src/test/resources</directory>
                 <filtering>true</filtering>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources-glassfish-managed</directory>
             </testResource>
         </testResources>
     </build>

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/ComptoirEJB.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/ComptoirEJB.java
@@ -1,0 +1,7 @@
+package be.valuya.comptoir;
+
+/**
+ * Created by cghislai on 31/03/16.
+ */
+public class ComptoirEJB {
+}

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/model/accounting/Account.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/model/accounting/Account.java
@@ -2,19 +2,13 @@ package be.valuya.comptoir.model.accounting;
 
 import be.valuya.comptoir.model.company.Company;
 import be.valuya.comptoir.model.lang.LocaleText;
-import java.io.Serializable;
-import java.util.Objects;
+
 import javax.annotation.Nonnull;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
  *
@@ -41,7 +35,7 @@ public class Account implements Serializable {
     @Size(max = 12)
     private String bic;
     private String name;
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     private LocaleText description;
     @Enumerated(EnumType.STRING)
     @NotNull

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/model/accounting/CustomerLoyaltyAccountingEntry.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/model/accounting/CustomerLoyaltyAccountingEntry.java
@@ -30,7 +30,6 @@ public class CustomerLoyaltyAccountingEntry implements Serializable {
     @NotNull
     @Nonnull
     private BigDecimal amount;
-    @Temporal(TemporalType.TIMESTAMP)
     @NotNull
     @Nonnull
     private ZonedDateTime dateTime;

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/model/commercial/ItemVariantSale.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/model/commercial/ItemVariantSale.java
@@ -32,7 +32,7 @@ public class ItemVariantSale implements Serializable {
     private BigDecimal total;
     @ManyToOne
     private Sale sale;
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     private LocaleText comment;
     @OneToOne
     private AccountingEntry accountingEntry;

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/model/stock/ItemStock.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/model/stock/ItemStock.java
@@ -24,10 +24,8 @@ public class ItemStock implements Serializable {
     @GeneratedValue
     private Long id;
     @Column(name = "start_date_time")
-    @Temporal(TemporalType.TIMESTAMP)
     private ZonedDateTime startDateTime;
     @Column(name = "end_date_time")
-    @Temporal(TemporalType.TIMESTAMP)
     private ZonedDateTime endDateTime;
     @Column(name = "order_position")
     @CheckForNull

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/model/stock/Stock.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/model/stock/Stock.java
@@ -4,15 +4,12 @@ import be.valuya.comptoir.model.common.Activable;
 import be.valuya.comptoir.model.common.WithId;
 import be.valuya.comptoir.model.company.Company;
 import be.valuya.comptoir.model.lang.LocaleText;
+
+import javax.annotation.Nonnull;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 
 /**
  *
@@ -29,7 +26,7 @@ public class Stock implements Serializable, Activable, WithId {
     @Nonnull
     @ManyToOne(optional = false)
     private Company company;
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     private LocaleText description;
     private boolean active;
 

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/AttributeDefinitionColumnPersistenceUtil.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/AttributeDefinitionColumnPersistenceUtil.java
@@ -1,0 +1,40 @@
+package be.valuya.comptoir.service;
+
+import be.valuya.comptoir.model.commercial.AttributeDefinition;
+import be.valuya.comptoir.model.commercial.AttributeDefinition_;
+import be.valuya.comptoir.model.lang.LocaleText;
+import be.valuya.comptoir.model.lang.LocaleText_;
+import be.valuya.comptoir.util.pagination.AttributeDefinitionColumn;
+
+import javax.persistence.criteria.*;
+import java.util.Locale;
+
+/**
+ * @author Yannick Majoros <yannick@valuya.be>
+ */
+public class AttributeDefinitionColumnPersistenceUtil {
+
+    public static Expression<?> getPath(From<?, AttributeDefinition> definitionFrom, AttributeDefinitionColumn column, Locale locale, CriteriaBuilder builder) {
+        switch (column) {
+            case NAME:
+                Join<AttributeDefinition, LocaleText> definitionLocaleTextJoin = definitionFrom.join(AttributeDefinition_.name);
+
+                MapJoin<LocaleText, Locale, String> localeTextLocaleStringMapJoin = definitionLocaleTextJoin.join(LocaleText_.localeTextMap);
+                Path<Locale> localePath = localeTextLocaleStringMapJoin.key();
+                Predicate localePredicate = builder.equal(localePath, locale);
+                localeTextLocaleStringMapJoin.on(localePredicate);
+
+                Path<String> nameValue = localeTextLocaleStringMapJoin.value();
+
+                Predicate noNamePredicate = builder.isNull(definitionLocaleTextJoin);
+                CriteriaBuilder.SimpleCase<Boolean, String> nameSelectCase = builder.selectCase(noNamePredicate);
+                Expression<String> nameResult = nameSelectCase
+                        .when(true, builder.nullLiteral(String.class))
+                        .otherwise(nameValue);
+                return nameResult;
+            default:
+                throw new AssertionError(column.name());
+        }
+    }
+
+}

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/CompanyService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/CompanyService.java
@@ -1,12 +1,17 @@
 package be.valuya.comptoir.service;
 
 import be.valuya.comptoir.model.company.Company;
+
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 
 /**
- *
  * @author Yannick Majoros <yannick@valuya.be>
  */
 @Stateless
@@ -14,6 +19,18 @@ public class CompanyService {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    public Long countCompanies() {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = criteriaBuilder.createQuery(Long.class);
+        Root<Company> companyRoot = query.from(Company.class);
+
+        Expression<Long> companyCount = criteriaBuilder.count(companyRoot);
+        query.select(companyCount);
+
+        TypedQuery<Long> typedQuery = entityManager.createQuery(query);
+        return typedQuery.getSingleResult();
+    }
 
     public Company saveCompany(Company company) {
         return entityManager.merge(company);

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/PaginatedQueryService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/PaginatedQueryService.java
@@ -12,7 +12,6 @@ import javax.persistence.TypedQuery;
 import javax.persistence.criteria.*;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -102,16 +101,9 @@ public class PaginatedQueryService {
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> query = criteriaBuilder.createQuery(Long.class);
 
-        // No root in the query prevent it to be validated by Hibernate JPA
-        // Joins are required as predicates as applied
-        // FIXME: probably subqueries root should be added as well
-        Root<? extends T> countRoot = query.from(root.getJavaType());
-        Set<Join<T, ?>> joins = root.getJoins();
-        for (Join join : joins) {
-            countRoot.join(join.getAttribute().getName(), join.getJoinType());
-        }
+        query.getRoots().add(root);
 
-        Expression<Long> countExpression = criteriaBuilder.count(countRoot);
+        Expression<Long> countExpression = criteriaBuilder.count(root);
         query.select(countExpression);
 
         Predicate[] predicateArray = predicates.toArray(new Predicate[0]);

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/PaginatedQueryService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/PaginatedQueryService.java
@@ -16,7 +16,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- *
  * @author Yannick Majoros <yannick@valuya.be>
  */
 @Stateless
@@ -33,7 +32,7 @@ public class PaginatedQueryService {
         return items;
     }
 
-    public <T, C extends Column<T>> void applySort(Pagination<T, C> pagination, From<?, T> from, CriteriaQuery<T> query, Function<C, Path<?>> sortToPathFunction) {
+    public <T, C extends Column<T>> void applySort(Pagination<T, C> pagination, From<?, T> from, CriteriaQuery<T> query, Function<C, Expression<?>> sortToPathFunction) {
         if (pagination != null) {
             List<Order> orders = createOrders(pagination, from, sortToPathFunction);
             query.orderBy(orders);
@@ -61,7 +60,7 @@ public class PaginatedQueryService {
         }
     }
 
-    private <T, C extends Column<T>> List<Order> createOrders(Pagination<T, C> pagination, From<?, T> from, Function<C, Path<?>> sortToPathFunction) {
+    private <T, C extends Column<T>> List<Order> createOrders(Pagination<T, C> pagination, From<?, T> from, Function<C, Expression<?>> sortToPathFunction) {
         List<Sort<C>> sortings = pagination.getSortings();
         if (sortings == null) {
             return Arrays.asList();
@@ -74,9 +73,9 @@ public class PaginatedQueryService {
         return orders;
     }
 
-    private <T, C extends Column<T>> Order createOrder(Sort<C> sort, Function<C, Path<?>> sortToPathFunction) {
+    private <T, C extends Column<T>> Order createOrder(Sort<C> sort, Function<C, Expression<?>> sortToPathFunction) {
         C sortColumn = sort.getSortColumn();
-        Path<?> path = sortToPathFunction.apply(sortColumn);
+        Expression<?> path = sortToPathFunction.apply(sortColumn);
         Order order;
         if (sort.isAscending()) {
             order = createAscOrder(path);
@@ -86,12 +85,12 @@ public class PaginatedQueryService {
         return order;
     }
 
-    private Order createDescOrder(Path<?> path) {
+    private Order createDescOrder(Expression<?> path) {
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         return criteriaBuilder.desc(path);
     }
 
-    private Order createAscOrder(Path<?> path) {
+    private Order createAscOrder(Expression<?> path) {
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         Order order = criteriaBuilder.asc(path);
         return order;

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/RegistrationService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/RegistrationService.java
@@ -10,16 +10,17 @@ import be.valuya.comptoir.model.lang.LocaleText;
 import be.valuya.comptoir.model.stock.Stock;
 import be.valuya.comptoir.model.thirdparty.Customer;
 import be.valuya.comptoir.model.thirdparty.Employee;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 /**
  *

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/SaleService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/SaleService.java
@@ -326,6 +326,7 @@ public class SaleService {
         List<ItemVariantSale> itemSaleList = findItemSales(sale);
         itemSaleList.forEach(this::removeItemSale);
 
+        // Remove accounting entries
         AccountingTransaction accountingTransaction = sale.getAccountingTransaction();
         Company company = sale.getCompany();
         AccountingEntrySearch accountingEntrySearch = new AccountingEntrySearch();
@@ -334,6 +335,16 @@ public class SaleService {
         List<AccountingEntry> accountingEntries = accountService.findAccountingEntries(accountingEntrySearch);
         for (AccountingEntry accountingEntry : accountingEntries) {
             accountService.removeAccountingEntry(accountingEntry);
+        }
+
+        // remove customer loyalty entry
+        try {
+            CustomerLoyaltyAccountingEntry saleCustomerLoyaltyEntry = findSaleCustomerLoyaltyEntry(sale);
+            if (saleCustomerLoyaltyEntry != null) {
+                removeCustomerLoyaltyAccountingEntry(saleCustomerLoyaltyEntry);
+            }
+        } catch (IllegalStateException e) {
+            throw new EJBException(e);
         }
 
         Sale managedSale = entityManager.merge(sale);

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/SaleService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/SaleService.java
@@ -310,10 +310,11 @@ public class SaleService {
         }
 
         calcSale(sale);
-        updateCustomerLoyaltyEntry(sale);
-
         Sale managedSale = entityManager.merge(sale);
+
+        updateCustomerLoyaltyEntry(managedSale);
         managedSale = calcSale(managedSale);
+
 
         return managedSale;
     }

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/StockService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/StockService.java
@@ -746,6 +746,18 @@ public class StockService {
         CriteriaQuery<AttributeDefinition> query = criteriaBuilder.createQuery(AttributeDefinition.class);
         Root<AttributeDefinition> attributeDefinitionRoot = query.from(AttributeDefinition.class);
 
+        List<Predicate> predicates = createAttributeDefinitionPredicates(attributeSearch, criteriaBuilder, query, attributeDefinitionRoot);
+        Locale locale = attributeSearch.getLocale();
+/*
+        paginatedQueryService.applySort(pagination, attributeDefinitionRoot, query,
+                (column) -> AttributeDefinitionColumnPersistenceUtil.getPath(attributeDefinitionRoot, column, locale, criteriaBuilder));
+*/
+
+        List<AttributeDefinition> attributeDefinitions = paginatedQueryService.getResults(predicates, query, attributeDefinitionRoot, pagination);
+        return attributeDefinitions;
+    }
+
+    private List<Predicate> createAttributeDefinitionPredicates(AttributeSearch attributeSearch, CriteriaBuilder criteriaBuilder, CriteriaQuery<AttributeDefinition> query, Root<AttributeDefinition> attributeDefinitionRoot) {
         List<Predicate> predicates = new ArrayList<>();
 
         Company company = attributeSearch.getCompany();
@@ -776,12 +788,7 @@ public class StockService {
             Predicate multiSearchPredicate = criteriaBuilder.or(nameContainsPredicate, hasValuePredicate);
             predicates.add(multiSearchPredicate);
         }
-
-        Predicate[] predicateArray = predicates.toArray(new Predicate[0]);
-        query.where(predicateArray);
-
-        TypedQuery<AttributeDefinition> typedQuery = entityManager.createQuery(query);
-        return typedQuery.getResultList();
+        return predicates;
     }
 
     private Predicate createAttributeHasValuePredicate(CriteriaQuery<AttributeDefinition> query, String valueContains, Root<AttributeDefinition> attributeDefinitionRoot, @CheckForNull Locale locale) {

--- a/comptoir-ejb/src/main/java/be/valuya/comptoir/service/StockService.java
+++ b/comptoir-ejb/src/main/java/be/valuya/comptoir/service/StockService.java
@@ -385,7 +385,7 @@ public class StockService {
         ItemStock managedPreviousItemStock = findItemStock(itemVariant, stock, fromDateTime);
         if (managedPreviousItemStock != null) {
             managedPreviousItemStock.setEndDateTime(fromDateTime);
-            entityManager.merge(managedPreviousItemStock);
+            managedPreviousItemStock = entityManager.merge(managedPreviousItemStock);
         }
 
         // create new stock value

--- a/comptoir-ejb/src/test/java/be/valuya/comptoir/service/JPATestBase.java
+++ b/comptoir-ejb/src/test/java/be/valuya/comptoir/service/JPATestBase.java
@@ -1,0 +1,178 @@
+package be.valuya.comptoir.service;
+
+import be.valuya.comptoir.ComptoirEJB;
+import be.valuya.comptoir.model.commercial.*;
+import be.valuya.comptoir.model.company.Company;
+import be.valuya.comptoir.model.company.Country;
+import be.valuya.comptoir.model.factory.LocaleTextFactory;
+import be.valuya.comptoir.model.lang.LocaleText;
+import be.valuya.comptoir.model.search.ItemSearch;
+import be.valuya.comptoir.model.search.ItemVariantSearch;
+import be.valuya.comptoir.model.search.StockSearch;
+import be.valuya.comptoir.model.stock.Stock;
+import be.valuya.comptoir.model.thirdparty.Employee;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.sessions.server.ServerSession;
+import org.eclipse.persistence.tools.schemaframework.SchemaManager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import javax.ejb.EJB;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Created by cghislai on 02/04/16.
+ */
+
+public abstract class JPATestBase {
+    @Deployment
+    public static JavaArchive createDeployment() {
+        JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addPackages(true, ComptoirEJB.class.getPackage())
+                .deleteClass(DbInitProducer.class)
+                .addAsManifestResource("META-INF/persistence.xml", "persistence.xml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return javaArchive;
+    }
+
+    @EJB
+    private CompanyService companyService;
+    @EJB
+    private SaleService saleService;
+    @EJB
+    private CountryService countryService;
+    @EJB
+    private StockService stockService;
+    @EJB
+    private LocaleTextFactory localeTextFactory;
+    @EJB
+    private RegistrationService registrationService;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    protected Country country;
+    protected Company company;
+    protected Stock defaultStock;
+
+    @Before
+    public void createData() {
+        Assert.assertNotNull(companyService);
+        Long countCompanies = companyService.countCompanies();
+        Assert.assertEquals("No companies yet", (long) countCompanies, 0L);
+
+        // Country
+        Country country = new Country();
+        country.setDefaultVatRate(BigDecimal.valueOf(0.21));
+        country.setCode("be");
+        Country managedCountry = countryService.saveCountry(country);
+        this.country =managedCountry;
+
+        // Company
+        LocaleText companyName = localeTextFactory.createLocaleText();
+        companyName.put(Locale.FRENCH, "Test");
+        Company company = new Company();
+        company.setCustomerLoyaltyRate(BigDecimal.valueOf(0.1));
+        company.setName(companyName);
+        company.setCountry(managedCountry);
+
+        Employee testEmployee = new Employee();
+        testEmployee.setFirstName("test");
+        testEmployee.setLastName("Poe");
+        testEmployee.setLocale(Locale.FRENCH);
+        testEmployee.setLogin("test");
+
+        Company managedCompany = registrationService.register(company, testEmployee, "test");
+        this.company = managedCompany;
+
+        countCompanies = companyService.countCompanies();
+        Assert.assertEquals("Company created", (long) countCompanies, 1L);
+
+        // Check default stock presence
+        StockSearch stockSearch = new StockSearch();
+        stockSearch.setCompany(this.company);
+        stockSearch.setActive(true);
+        List<Stock> stocks = stockService.findStocks(stockSearch, null);
+        Assert.assertFalse("Default stock created", stocks.isEmpty());
+        this.defaultStock = stocks.get(0);
+    }
+
+    @After
+    public void dropData() {
+        // FIXME: Eclipselink code
+        ServerSession serverSession = entityManager.unwrap(JpaEntityManager.class).getServerSession();
+        SchemaManager schemaManager = new SchemaManager(serverSession);
+        schemaManager.dropDefaultTables();
+        schemaManager.createDefaultTables(true);
+    }
+
+    protected Item createItem(String name, String reference, BigDecimal priceValue) {
+        LocaleText nameText = localeTextFactory.createLocaleText();
+        nameText.put(Locale.FRENCH, name);
+        LocaleText descriptionText = localeTextFactory.createLocaleText();
+        BigDecimal defaultVatRate = country.getDefaultVatRate();
+        Price price = new Price();
+        price.setVatRate(defaultVatRate);
+        price.setVatExclusive(priceValue);
+
+        Item item = new Item();
+        item.setActive(true);
+        item.setDescription(descriptionText);
+        item.setReference(reference);
+        item.setMultipleSale(false);
+        item.setCompany(company);
+        item.setCurrentPrice(price);
+        item.setName(nameText);
+        Item managedItem = stockService.saveItem(item);
+        return managedItem;
+    }
+
+    protected ItemVariant getDefaultVariant(Item item) {
+        ItemSearch itemSearch = new ItemSearch();
+        itemSearch.setCompany(company);
+        ItemVariantSearch itemVariantSearch = new ItemVariantSearch();
+        itemVariantSearch.setItem(item);
+        itemVariantSearch.setItemSearch(itemSearch);
+        itemVariantSearch.setVariantReference("default");
+
+        List<ItemVariant> itemVariants = stockService.findItemVariants(itemVariantSearch, null);
+        Assert.assertFalse(itemVariants.isEmpty());
+        ItemVariant itemVariant = itemVariants.get(0);
+        return itemVariant;
+    }
+
+    protected ItemVariant createVariant(Item item, String ref) {
+        ItemVariant itemVariant = new ItemVariant();
+        itemVariant.setActive(true);
+        itemVariant.setVariantReference(ref);
+        itemVariant.setPricing(Pricing.PARENT_ITEM);
+        itemVariant.setItem(item);
+        ItemVariant managedVariant = stockService.saveItemVariant(itemVariant);
+        return managedVariant;
+    }
+
+
+    public Sale createSale() {
+        Sale sale = new Sale();
+        sale.setCompany(company);
+        Sale managedSale = saleService.saveSale(sale);
+        return managedSale;
+    }
+
+    public ItemVariantSale createItemVariantSale(Sale sale, ItemVariant itemVariant) {
+        ItemVariantSale variantSale = new ItemVariantSale();
+        variantSale.setItemVariant(itemVariant);
+        variantSale.setSale(sale);
+        variantSale.setQuantity(BigDecimal.ONE);
+        ItemVariantSale managetVariantSale = saleService.saveItemSale(variantSale);
+        return managetVariantSale;
+    }
+}

--- a/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
+++ b/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
@@ -15,9 +15,7 @@ import be.valuya.comptoir.model.stock.StockChangeType;
 import be.valuya.comptoir.model.thirdparty.Employee;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -25,8 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.ejb.EJB;
-import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -44,19 +40,6 @@ public class StockEntriesTest {
                 .deleteClass(DbInitProducer.class)
                 .addAsManifestResource("META-INF/persistence.xml", "persistence.xml")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-        System.out.println(javaArchive.toString(true));
-        Node node = javaArchive.get("/META-INF/persistence.xml");
-        Asset asset = node.getAsset();
-        InputStream inputStream = asset.openStream();
-        try {
-            while (inputStream.available() > 0) {
-                int read = inputStream.read();
-                System.out.write(read);
-            }
-        } catch (IOException e) {
-
-
-        }
         return javaArchive;
     }
 

--- a/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
+++ b/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
@@ -139,7 +139,7 @@ public class StockEntriesTest extends JPATestBase {
         BigDecimal quantity = variantStock.getQuantity();
         BigDecimal expectedQuantity = BigDecimal.valueOf(expectedValue);
         int comparisonValue = quantity.compareTo(expectedQuantity);
-        Assert.assertEquals(comparisonValue, 0);
+        Assert.assertEquals(0, comparisonValue);
         return variantStock;
     }
 

--- a/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
+++ b/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
@@ -1,0 +1,293 @@
+package be.valuya.comptoir.service;
+
+import be.valuya.comptoir.ComptoirEJB;
+import be.valuya.comptoir.model.commercial.*;
+import be.valuya.comptoir.model.company.Company;
+import be.valuya.comptoir.model.company.Country;
+import be.valuya.comptoir.model.factory.LocaleTextFactory;
+import be.valuya.comptoir.model.lang.LocaleText;
+import be.valuya.comptoir.model.search.ItemSearch;
+import be.valuya.comptoir.model.search.ItemVariantSearch;
+import be.valuya.comptoir.model.search.StockSearch;
+import be.valuya.comptoir.model.stock.ItemStock;
+import be.valuya.comptoir.model.stock.Stock;
+import be.valuya.comptoir.model.stock.StockChangeType;
+import be.valuya.comptoir.model.thirdparty.Employee;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ejb.EJB;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Created by cghislai on 31/03/16.
+ */
+@RunWith(Arquillian.class)
+public class StockEntriesTest {
+    @Deployment
+    public static JavaArchive createDeployment() {
+        JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addPackages(true, ComptoirEJB.class.getPackage())
+                .deleteClass(DbInitProducer.class)
+                .addAsManifestResource("META-INF/persistence.xml", "persistence.xml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        System.out.println(javaArchive.toString(true));
+        Node node = javaArchive.get("/META-INF/persistence.xml");
+        Asset asset = node.getAsset();
+        InputStream inputStream = asset.openStream();
+        try {
+            while (inputStream.available() > 0) {
+                int read = inputStream.read();
+                System.out.write(read);
+            }
+        } catch (IOException e) {
+
+
+        }
+        return javaArchive;
+    }
+
+    @EJB
+    CompanyService companyService;
+    @EJB
+    SaleService saleService;
+    @EJB
+    CountryService countryService;
+    @EJB
+    StockService stockService;
+    @EJB
+    LocaleTextFactory localeTextFactory;
+    @EJB
+    RegistrationService registrationService;
+
+
+    private Company testCompany;
+    private Stock testDefaultStock;
+    private ItemVariant testVariantADefault;
+    private ItemVariant testVariantAA;
+    // MultipleSale
+    private ItemVariant testVariantBDefault;
+
+    @Test
+    public void testCreateStockEntry() {
+        Assert.assertNotNull(companyService);
+        Long countCompanies = companyService.countCompanies();
+        Assert.assertEquals("No companies yet", (long) countCompanies, 0L);
+
+        // Create company
+        createTestData();
+        countCompanies = companyService.countCompanies();
+        Assert.assertEquals("Company created", (long) countCompanies, 1L);
+
+        // Stock should be empty
+        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+
+        // Create a sale
+        Sale testSale = createTestSale();
+        Assert.assertFalse(testSale.isClosed());
+
+        // Create an itemSale
+        ItemVariantSale variantSaleAA = createItemVariantSale(testSale, testVariantAA);
+        variantSaleAA.setQuantity(BigDecimal.valueOf(2));
+        variantSaleAA = saleService.saveItemSale(variantSaleAA);
+
+        // Stock should still be empty
+        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+
+        // Close sale
+        testSale = saleService.closeSale(testSale);
+        Assert.assertTrue(testSale.isClosed());
+        // Stock should be set to -2
+        assertCurrentStockValue(testVariantAA, testDefaultStock, -2);
+
+        // Reopen the sale
+        testSale = saleService.reopenSale(testSale);
+        Assert.assertFalse(testSale.isClosed());
+
+        // Stock should be set back to null (no entries)
+        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+
+        // Create an initial stock entry for 10 units
+        ItemStock initialItemStock = stockService.adaptStock(ZonedDateTime.now(), testDefaultStock, testVariantAA, BigDecimal.valueOf(10), "init", StockChangeType.INITIAL, null);
+        assertCurrentStockValue(testVariantAA, testDefaultStock, 10);
+
+        // Create a second sale
+        Sale testSale2 = createTestSale();
+        // Add a single variant
+        ItemVariantSale variantSaleAA2 = createItemVariantSale(testSale2, testVariantAA);
+        variantSaleAA2 = saleService.saveItemSale(variantSaleAA2);
+        // Close it
+        testSale2 = saleService.closeSale(testSale2);
+        // Stock should contains 9 units
+        ItemStock sale2VariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 9);
+        // Stock entry parent should be the initial stock entry
+        ItemStock previousItemStock2 = sale2VariantStock.getPreviousItemStock();
+        Assert.assertEquals(initialItemStock, previousItemStock2);
+
+        // Close the first Sale
+        saleService.closeSale(testSale);
+        // Stock should contains 7 units
+        ItemStock sale1VariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 7);
+        ItemStock previousItemStock = sale1VariantStock.getPreviousItemStock();
+        // Parent should be previousItemStock2
+        Assert.assertEquals(previousItemStock, sale2VariantStock);
+
+        // Reopen the second sale
+        saleService.reopenSale(testSale2);
+        // Stock should be back to 8
+        ItemStock currentVariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 8);
+        // And its parent entry should be the initial one
+        ItemStock previousItemStock1 = currentVariantStock.getPreviousItemStock();
+        Assert.assertEquals(previousItemStock1, initialItemStock);
+
+        // Reopen the first sale
+        saleService.reopenSale(testSale);
+        // Stock should be back at 10
+        assertCurrentStockValue(testVariantAA, testDefaultStock, 10);
+
+    }
+
+    public ItemStock assertCurrentStockValue(ItemVariant itemVariant, Stock stock, Integer expectedValue) {
+        ItemStock variantStock = stockService.findItemStock(itemVariant, stock, ZonedDateTime.now());
+        if (expectedValue == null) {
+            Assert.assertNull(variantStock);
+            return null;
+        }
+        Assert.assertNotNull(variantStock);
+        BigDecimal quantity = variantStock.getQuantity();
+        BigDecimal expectedQuantity = BigDecimal.valueOf(expectedValue);
+        int comparisonValue = quantity.compareTo(expectedQuantity);
+        Assert.assertEquals(comparisonValue, 0);
+        return variantStock;
+    }
+
+    public void createTestData() {
+        // Country
+        Country country = new Country();
+        country.setDefaultVatRate(BigDecimal.valueOf(0.21));
+        country.setCode("be");
+        Country managedCountry = countryService.saveCountry(country);
+
+        // Company
+        LocaleText companyName = localeTextFactory.createLocaleText();
+        companyName.put(Locale.FRENCH, "Test");
+        Company company = new Company();
+        company.setCustomerLoyaltyRate(BigDecimal.valueOf(0.1));
+        company.setName(companyName);
+        company.setCountry(managedCountry);
+
+        Employee testEmployee = new Employee();
+        testEmployee.setFirstName("test");
+        testEmployee.setLastName("Poe");
+        testEmployee.setLocale(Locale.FRENCH);
+        testEmployee.setLogin("test");
+
+        Company managedCompany = registrationService.register(company, testEmployee, "test");
+        testCompany = managedCompany;
+
+
+        // Check default stock presence
+        StockSearch stockSearch = new StockSearch();
+        stockSearch.setCompany(testCompany);
+        stockSearch.setActive(true);
+        List<Stock> stocks = stockService.findStocks(stockSearch, null);
+        Assert.assertFalse("Default stock created", stocks.isEmpty());
+        testDefaultStock = stocks.get(0);
+
+        // Item A
+        LocaleText itemAName = localeTextFactory.createLocaleText();
+        itemAName.put(Locale.FRENCH, "A");
+        LocaleText itemADesc = localeTextFactory.createLocaleText();
+        itemADesc.put(Locale.FRENCH, "A long description");
+        Price itemAPrice = new Price();
+        itemAPrice.setVatExclusive(BigDecimal.valueOf(9.99));
+        itemAPrice.setVatRate(country.getDefaultVatRate());
+        Item itemA = new Item();
+        itemA.setCompany(managedCompany);
+        itemA.setName(itemAName);
+        itemA.setDescription(itemADesc);
+        itemA.setActive(true);
+        itemA.setCurrentPrice(itemAPrice);
+        itemA.setReference("A");
+        itemA.setMultipleSale(false);
+        Item managedItemA = stockService.saveItem(itemA);
+
+        // Should have a default variant set
+        ItemSearch itemSearch = new ItemSearch();
+        itemSearch.setCompany(testCompany);
+        ItemVariantSearch itemVariantSearch = new ItemVariantSearch();
+        itemVariantSearch.setItem(managedItemA);
+        itemVariantSearch.setItemSearch(itemSearch);
+
+        List<ItemVariant> itemVariants = stockService.findItemVariants(itemVariantSearch, null);
+        Assert.assertFalse(itemVariants.isEmpty());
+        ItemVariant variantADefault = itemVariants.get(0);
+        this.testVariantADefault = variantADefault;
+
+        // Variant A-A
+        ItemVariant variantAA = new ItemVariant();
+        variantAA.setActive(true);
+        variantAA.setItem(managedItemA);
+        variantAA.setPricing(Pricing.ADD_TO_BASE);
+        variantAA.setPricingAmount(BigDecimal.valueOf(5)); // 14.99
+        variantAA.setVariantReference("A");
+        ItemVariant managedVariantAA = stockService.saveItemVariant(variantAA);
+        this.testVariantAA = managedVariantAA;
+
+        // Item B
+        LocaleText itemBName = localeTextFactory.createLocaleText();
+        itemBName.put(Locale.FRENCH, "itemB");
+        LocaleText itemBDesc = localeTextFactory.createLocaleText();
+        itemBDesc.put(Locale.FRENCH, "A long description for B");
+        Price itemBPrice = new Price();
+        itemBPrice.setVatExclusive(BigDecimal.valueOf(9.99));
+        itemBPrice.setVatRate(country.getDefaultVatRate());
+        Item itemB = new Item();
+        itemB.setCompany(managedCompany);
+        itemB.setName(itemBName);
+        itemB.setDescription(itemBDesc);
+        itemB.setActive(true);
+        itemB.setMultipleSale(true);
+        itemB.setCurrentPrice(itemBPrice);
+        itemB.setReference("itemB");
+        itemB.setMultipleSale(false);
+        Item managedItemB = stockService.saveItem(itemB);
+
+        // Default itemB variant
+        itemVariantSearch.setItem(managedItemB);
+        itemVariants = stockService.findItemVariants(itemVariantSearch, null);
+        Assert.assertFalse(itemVariants.isEmpty());
+        ItemVariant variantBDefault = itemVariants.get(0);
+        this.testVariantBDefault = variantBDefault;
+    }
+
+    public Sale createTestSale() {
+        Sale sale = new Sale();
+        sale.setCompany(testCompany);
+        Sale managedSale = saleService.saveSale(sale);
+        return managedSale;
+    }
+
+    public ItemVariantSale createItemVariantSale(Sale sale, ItemVariant itemVariant) {
+        ItemVariantSale variantSale = new ItemVariantSale();
+        variantSale.setItemVariant(itemVariant);
+        variantSale.setSale(sale);
+        variantSale.setQuantity(BigDecimal.ONE);
+        ItemVariantSale managetVariantSale = saleService.saveItemSale(variantSale);
+        return managetVariantSale;
+    }
+
+}

--- a/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
+++ b/comptoir-ejb/src/test/java/be/valuya/comptoir/service/StockEntriesTest.java
@@ -1,23 +1,14 @@
 package be.valuya.comptoir.service;
 
-import be.valuya.comptoir.ComptoirEJB;
-import be.valuya.comptoir.model.commercial.*;
-import be.valuya.comptoir.model.company.Company;
-import be.valuya.comptoir.model.company.Country;
+import be.valuya.comptoir.model.commercial.Item;
+import be.valuya.comptoir.model.commercial.ItemVariant;
+import be.valuya.comptoir.model.commercial.ItemVariantSale;
+import be.valuya.comptoir.model.commercial.Sale;
 import be.valuya.comptoir.model.factory.LocaleTextFactory;
-import be.valuya.comptoir.model.lang.LocaleText;
-import be.valuya.comptoir.model.search.ItemSearch;
-import be.valuya.comptoir.model.search.ItemVariantSearch;
-import be.valuya.comptoir.model.search.StockSearch;
 import be.valuya.comptoir.model.stock.ItemStock;
 import be.valuya.comptoir.model.stock.Stock;
 import be.valuya.comptoir.model.stock.StockChangeType;
-import be.valuya.comptoir.model.thirdparty.Employee;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,24 +16,12 @@ import org.junit.runner.RunWith;
 import javax.ejb.EJB;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * Created by cghislai on 31/03/16.
  */
 @RunWith(Arquillian.class)
-public class StockEntriesTest {
-    @Deployment
-    public static JavaArchive createDeployment() {
-        JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
-                .addPackages(true, ComptoirEJB.class.getPackage())
-                .deleteClass(DbInitProducer.class)
-                .addAsManifestResource("META-INF/persistence.xml", "persistence.xml")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-        return javaArchive;
-    }
-
+public class StockEntriesTest extends JPATestBase {
     @EJB
     CompanyService companyService;
     @EJB
@@ -57,89 +36,96 @@ public class StockEntriesTest {
     RegistrationService registrationService;
 
 
-    private Company testCompany;
-    private Stock testDefaultStock;
-    private ItemVariant testVariantADefault;
-    private ItemVariant testVariantAA;
-    // MultipleSale
-    private ItemVariant testVariantBDefault;
+    private Sale saleA;
+    private Sale saleB;
+    private ItemVariant variantA;
+    private ItemVariant variantB;
+
 
     @Test
     public void testCreateStockEntry() {
-        Assert.assertNotNull(companyService);
-        Long countCompanies = companyService.countCompanies();
-        Assert.assertEquals("No companies yet", (long) countCompanies, 0L);
-
-        // Create company
-        createTestData();
-        countCompanies = companyService.countCompanies();
-        Assert.assertEquals("Company created", (long) countCompanies, 1L);
+        createItems();
 
         // Stock should be empty
-        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+        assertCurrentStockValue(variantA, defaultStock, null);
+        assertCurrentStockValue(variantB, defaultStock, null);
 
-        // Create a sale
-        Sale testSale = createTestSale();
-        Assert.assertFalse(testSale.isClosed());
+        // Create saleA
+        saleA = createSale();
+        Assert.assertFalse(saleA.isClosed());
 
-        // Create an itemSale
-        ItemVariantSale variantSaleAA = createItemVariantSale(testSale, testVariantAA);
-        variantSaleAA.setQuantity(BigDecimal.valueOf(2));
-        variantSaleAA = saleService.saveItemSale(variantSaleAA);
+        // Add variant A
+        ItemVariantSale variantASaleA = createItemVariantSale(saleA, variantA);
+        // 2 units
+        variantASaleA.setQuantity(BigDecimal.valueOf(2));
+        variantASaleA = saleService.saveItemSale(variantASaleA);
 
         // Stock should still be empty
-        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+        assertCurrentStockValue(variantA, defaultStock, null);
 
         // Close sale
-        testSale = saleService.closeSale(testSale);
-        Assert.assertTrue(testSale.isClosed());
+        saleA = saleService.closeSale(saleA);
+        Assert.assertTrue(saleA.isClosed());
+
         // Stock should be set to -2
-        assertCurrentStockValue(testVariantAA, testDefaultStock, -2);
+        assertCurrentStockValue(variantA, defaultStock, -2);
 
         // Reopen the sale
-        testSale = saleService.reopenSale(testSale);
-        Assert.assertFalse(testSale.isClosed());
+        saleA = saleService.reopenSale(saleA);
+        Assert.assertFalse(saleA.isClosed());
 
         // Stock should be set back to null (no entries)
-        assertCurrentStockValue(testVariantAA, testDefaultStock, null);
+        assertCurrentStockValue(variantA, defaultStock, null);
 
-        // Create an initial stock entry for 10 units
-        ItemStock initialItemStock = stockService.adaptStock(ZonedDateTime.now(), testDefaultStock, testVariantAA, BigDecimal.valueOf(10), "init", StockChangeType.INITIAL, null);
-        assertCurrentStockValue(testVariantAA, testDefaultStock, 10);
 
-        // Create a second sale
-        Sale testSale2 = createTestSale();
-        // Add a single variant
-        ItemVariantSale variantSaleAA2 = createItemVariantSale(testSale2, testVariantAA);
-        variantSaleAA2 = saleService.saveItemSale(variantSaleAA2);
+        // Create Initial stock values of 10 units
+        ItemStock initialVariantAStock = stockService.adaptStock(ZonedDateTime.now(), defaultStock, variantA, BigDecimal.valueOf(10), "init", StockChangeType.INITIAL, null);
+        assertCurrentStockValue(variantA, defaultStock, 10);
+        ItemStock initialVariantBStock = stockService.adaptStock(ZonedDateTime.now(), defaultStock, variantB, BigDecimal.valueOf(10), "init", StockChangeType.INITIAL, null);
+        assertCurrentStockValue(variantB, defaultStock, 10);
+
+        // Create Sale B
+        saleB = createSale();
+        // Add 5 items of each
+        ItemVariantSale variantASaleB = createItemVariantSale(saleB, variantA);
+        variantASaleB.setQuantity(BigDecimal.valueOf(5));
+        variantASaleB = saleService.saveItemSale(variantASaleB);
+        ItemVariantSale variantBSaleB = createItemVariantSale(saleB, variantB);
+        variantBSaleB.setQuantity(BigDecimal.valueOf(5));
+        variantBSaleB = saleService.saveItemSale(variantBSaleB);
+
         // Close it
-        testSale2 = saleService.closeSale(testSale2);
-        // Stock should contains 9 units
-        ItemStock sale2VariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 9);
-        // Stock entry parent should be the initial stock entry
-        ItemStock previousItemStock2 = sale2VariantStock.getPreviousItemStock();
-        Assert.assertEquals(initialItemStock, previousItemStock2);
+        saleB = saleService.closeSale(saleB);
+        // Stocks should contains 5 units each
+        ItemStock afterSaleBVariantAStock = assertCurrentStockValue(variantA, defaultStock, 5);
+        ItemStock afterSaleBVariantBStock = assertCurrentStockValue(variantB, defaultStock, 5);
+
+        // Variant A stock item should follow initial stock item
+        ItemStock beforeSaleBVariantAStock = afterSaleBVariantAStock.getPreviousItemStock();
+        Assert.assertEquals(initialVariantAStock, beforeSaleBVariantAStock);
 
         // Close the first Sale
-        saleService.closeSale(testSale);
-        // Stock should contains 7 units
-        ItemStock sale1VariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 7);
-        ItemStock previousItemStock = sale1VariantStock.getPreviousItemStock();
-        // Parent should be previousItemStock2
-        Assert.assertEquals(previousItemStock, sale2VariantStock);
+        saleA = saleService.closeSale(saleA);
+
+        // Stock A should contains 3 units
+        ItemStock afterSaleAVariantAStock = assertCurrentStockValue(variantA, defaultStock, 3);
+
+        // Previous stock entry should be the one after sale B
+        ItemStock beforeSaleAVariantAStock = afterSaleAVariantAStock.getPreviousItemStock();
+        Assert.assertEquals(beforeSaleAVariantAStock, afterSaleBVariantAStock);
 
         // Reopen the second sale
-        saleService.reopenSale(testSale2);
-        // Stock should be back to 8
-        ItemStock currentVariantStock = assertCurrentStockValue(testVariantAA, testDefaultStock, 8);
-        // And its parent entry should be the initial one
-        ItemStock previousItemStock1 = currentVariantStock.getPreviousItemStock();
-        Assert.assertEquals(previousItemStock1, initialItemStock);
+        saleB = saleService.reopenSale(saleB);
+        // Stock should be back to 3 + 5 = 8
+        ItemStock currentVariantAStock = assertCurrentStockValue(variantA, defaultStock, 8);
+        // Parent stock entry should be the initial stock
+        ItemStock previousVariantAStock = currentVariantAStock.getPreviousItemStock();
+        Assert.assertEquals(previousVariantAStock, initialVariantAStock);
 
         // Reopen the first sale
-        saleService.reopenSale(testSale);
+        saleA = saleService.reopenSale(saleA);
         // Stock should be back at 10
-        assertCurrentStockValue(testVariantAA, testDefaultStock, 10);
+        assertCurrentStockValue(variantA, defaultStock, 10);
 
     }
 
@@ -157,120 +143,14 @@ public class StockEntriesTest {
         return variantStock;
     }
 
-    public void createTestData() {
-        // Country
-        Country country = new Country();
-        country.setDefaultVatRate(BigDecimal.valueOf(0.21));
-        country.setCode("be");
-        Country managedCountry = countryService.saveCountry(country);
+    public void createItems() {
+        Item itemA = createItem("A", "A", BigDecimal.valueOf(9.99));
+        variantA = getDefaultVariant(itemA);
 
-        // Company
-        LocaleText companyName = localeTextFactory.createLocaleText();
-        companyName.put(Locale.FRENCH, "Test");
-        Company company = new Company();
-        company.setCustomerLoyaltyRate(BigDecimal.valueOf(0.1));
-        company.setName(companyName);
-        company.setCountry(managedCountry);
-
-        Employee testEmployee = new Employee();
-        testEmployee.setFirstName("test");
-        testEmployee.setLastName("Poe");
-        testEmployee.setLocale(Locale.FRENCH);
-        testEmployee.setLogin("test");
-
-        Company managedCompany = registrationService.register(company, testEmployee, "test");
-        testCompany = managedCompany;
-
-
-        // Check default stock presence
-        StockSearch stockSearch = new StockSearch();
-        stockSearch.setCompany(testCompany);
-        stockSearch.setActive(true);
-        List<Stock> stocks = stockService.findStocks(stockSearch, null);
-        Assert.assertFalse("Default stock created", stocks.isEmpty());
-        testDefaultStock = stocks.get(0);
-
-        // Item A
-        LocaleText itemAName = localeTextFactory.createLocaleText();
-        itemAName.put(Locale.FRENCH, "A");
-        LocaleText itemADesc = localeTextFactory.createLocaleText();
-        itemADesc.put(Locale.FRENCH, "A long description");
-        Price itemAPrice = new Price();
-        itemAPrice.setVatExclusive(BigDecimal.valueOf(9.99));
-        itemAPrice.setVatRate(country.getDefaultVatRate());
-        Item itemA = new Item();
-        itemA.setCompany(managedCompany);
-        itemA.setName(itemAName);
-        itemA.setDescription(itemADesc);
-        itemA.setActive(true);
-        itemA.setCurrentPrice(itemAPrice);
-        itemA.setReference("A");
-        itemA.setMultipleSale(false);
-        Item managedItemA = stockService.saveItem(itemA);
-
-        // Should have a default variant set
-        ItemSearch itemSearch = new ItemSearch();
-        itemSearch.setCompany(testCompany);
-        ItemVariantSearch itemVariantSearch = new ItemVariantSearch();
-        itemVariantSearch.setItem(managedItemA);
-        itemVariantSearch.setItemSearch(itemSearch);
-
-        List<ItemVariant> itemVariants = stockService.findItemVariants(itemVariantSearch, null);
-        Assert.assertFalse(itemVariants.isEmpty());
-        ItemVariant variantADefault = itemVariants.get(0);
-        this.testVariantADefault = variantADefault;
-
-        // Variant A-A
-        ItemVariant variantAA = new ItemVariant();
-        variantAA.setActive(true);
-        variantAA.setItem(managedItemA);
-        variantAA.setPricing(Pricing.ADD_TO_BASE);
-        variantAA.setPricingAmount(BigDecimal.valueOf(5)); // 14.99
-        variantAA.setVariantReference("A");
-        ItemVariant managedVariantAA = stockService.saveItemVariant(variantAA);
-        this.testVariantAA = managedVariantAA;
-
-        // Item B
-        LocaleText itemBName = localeTextFactory.createLocaleText();
-        itemBName.put(Locale.FRENCH, "itemB");
-        LocaleText itemBDesc = localeTextFactory.createLocaleText();
-        itemBDesc.put(Locale.FRENCH, "A long description for B");
-        Price itemBPrice = new Price();
-        itemBPrice.setVatExclusive(BigDecimal.valueOf(9.99));
-        itemBPrice.setVatRate(country.getDefaultVatRate());
-        Item itemB = new Item();
-        itemB.setCompany(managedCompany);
-        itemB.setName(itemBName);
-        itemB.setDescription(itemBDesc);
-        itemB.setActive(true);
+        Item itemB = createItem("B", "B", BigDecimal.valueOf(8.99));
         itemB.setMultipleSale(true);
-        itemB.setCurrentPrice(itemBPrice);
-        itemB.setReference("itemB");
-        itemB.setMultipleSale(false);
-        Item managedItemB = stockService.saveItem(itemB);
-
-        // Default itemB variant
-        itemVariantSearch.setItem(managedItemB);
-        itemVariants = stockService.findItemVariants(itemVariantSearch, null);
-        Assert.assertFalse(itemVariants.isEmpty());
-        ItemVariant variantBDefault = itemVariants.get(0);
-        this.testVariantBDefault = variantBDefault;
-    }
-
-    public Sale createTestSale() {
-        Sale sale = new Sale();
-        sale.setCompany(testCompany);
-        Sale managedSale = saleService.saveSale(sale);
-        return managedSale;
-    }
-
-    public ItemVariantSale createItemVariantSale(Sale sale, ItemVariant itemVariant) {
-        ItemVariantSale variantSale = new ItemVariantSale();
-        variantSale.setItemVariant(itemVariant);
-        variantSale.setSale(sale);
-        variantSale.setQuantity(BigDecimal.ONE);
-        ItemVariantSale managetVariantSale = saleService.saveItemSale(variantSale);
-        return managetVariantSale;
+        itemB = stockService.saveItem(itemB);
+        variantB = getDefaultVariant(itemB);
     }
 
 }

--- a/comptoir-ejb/src/test/resources/META-INF/persistence.xml
+++ b/comptoir-ejb/src/test/resources/META-INF/persistence.xml
@@ -2,11 +2,13 @@
 <persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
-    <persistence-unit name="comptoirTestPU" >
-        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <persistence-unit name="comptoirTestPU"  transaction-type="JTA">
+        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
         <jar-file>${project.basedir}/target/classes</jar-file>
         <shared-cache-mode>ALL</shared-cache-mode>
         <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="eclipselink.logging.level" value="INFO" />
             <property name="eclipselink.logging.level.sql" value="INFO" />
             <property name="eclipselink.logging.parameters" value="true" />

--- a/comptoir-ejb/src/test/resources/META-INF/persistence.xml
+++ b/comptoir-ejb/src/test/resources/META-INF/persistence.xml
@@ -3,22 +3,15 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
     <persistence-unit name="comptoirTestPU"  transaction-type="JTA">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
-        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
-        <jar-file>${project.basedir}/target/classes</jar-file>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <jta-data-source>jdbc/comptoirtest</jta-data-source>
         <shared-cache-mode>ALL</shared-cache-mode>
         <properties>
-            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="eclipselink.logging.level" value="INFO" />
             <property name="eclipselink.logging.level.sql" value="INFO" />
             <property name="eclipselink.logging.parameters" value="true" />
 
             <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
-
-            <property name="javax.persistence.jdbc.driver" value="org.apache.derby.jdbc.EmbeddedDriver"/>
-            <property name="javax.persistence.jdbc.url" value="jdbc:derby:memory:jdbc/comptoir;create=true"/>
-            <property name="javax.persistence.jdbc.user" value="comptoir"/>
-            <property name="javax.persistence.jdbc.password" value=""/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
I set up the Arquillian environment for comptoir-ejb
It is bound to a maven profile 'test'. 
I launch the maven test goal with the following settings:
- WorkDir: comptoir-ejb
- command line arguments: test -Ddb.napo.driver=com.mysql.jdbc.Driver -Ddb.napo.url=jdbc:mysql://localhost:3306/petitnapo -Ddb.napo.username=... -Ddb.napo.password=...
  -P test

The plugins in the POM will download a wildfly and start it as the Arquilllian container. I took Wildfly because it looked like the only JEE7 container supported.
The persistence.xml point to the default datasource enabled in the wildfly default config.
The persistence provider is Hibernate, so I had to make some small changes to support it.
I created a StockEntries test to ensure stock entries are correctly updated when sales are open/closed.

The embedded wildfly will bind to port 8080, so it cannot be used when running the test suite.
