### PR TITLE
Fix thorntail deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .idea
 **/*.iml
 **/*.private.env.json
+.secrets

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,10 +40,10 @@ pipeline {
             steps {
                 unstash 'thorntail-jar'
                 sh '''
+                    cd comptoir-thorntail
                     export COMMIT="$(git rev-parse --short HEAD)"
                     docker build \
                       --tag comptoir-thorntail-jenkins-build:${COMMIT} \
-                      -f comptoir-thorntail/Dockerfile \
                       .
                     docker tag comptoir-thorntail-jenkins-build:${COMMIT} docker.valuya.be/comptoir-thorntail:latest
                     docker push docker.valuya.be/comptoir-thorntail:latest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                         clean package deploy
                     '''
                }
-               stash includes: 'comptoir-thorntail/Dockerfile,comptoir-thorntail/target/comptoir-thorntail-thorntail.jar', name: 'thorntail-jar'
+               stash includes: 'comptoir-thorntail/Dockerfile,comptoir-thorntail/target/comptoir-thorntail.jar', name: 'thorntail-jar'
                stash includes: 'docker/**,comptoir-ear/target/comptoir-ear.ear', name: 'docker-ear'
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 comptoir
 ========
+
+# Prerequistes
+## settings.xml
+
+```
+
+<profile>
+    <id>comptoir-napo</id>
+    <properties>
+        <db.napo.url>jdbc:mariadb://localhost:22306/napo</db.napo.url>
+        <db.napo.username>root</db.napo.username>
+        <db.napo.password>NAPO DB PASSWORD</db.napo.password>
+        <db.napo.schema>napo</db.napo.schema>
+    </properties>
+</profile>
+<profile>
+    <id>comptoir-thorntail</id>
+    <properties>
+            <comptoir.datasource.connection.password>DB PASSWORD</comptoir.datasource.connection.password>
+            <comptoir.https.keytore.path>/certs/comptoir.local.p12</comptoir.https.keytore.path>
+            <comptoir.https.keytore.password>password</comptoir.https.keytore.password>
+            <comptoir.https.key.alias>comptoir.local</comptoir.https.key.alias>
+            <comptoir.https.key.password>password</comptoir.https.key.password>
+    </properties>
+</profile>
+
+```
+
+## workdir ./secrets
+secret files mounted in db containers
+
+- db-root-password
+- napo-db-root-password
+
+## Initial dumps
+- ../res/ relative to workdir (see compose file)
+
+# Running
+
+- docker-compose up -d db napo-db (wait for dump to import)
+- mvn clean install
+- docker-compose up --build back

--- a/comptoir-ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/comptoir-ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+    <deployment>
+        <dependencies>
+            <module name="org.bouncycastle"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/comptoir-thorntail/Dockerfile
+++ b/comptoir-thorntail/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-COPY comptoir-thorntail/target/comptoir-thorntail-thorntail.jar /comptoir-thorntail.jar
+COPY ./target/comptoir-thorntail.jar /comptoir-thorntail.jar
 
 ENTRYPOINT ["java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8787" ]
 

--- a/comptoir-thorntail/pom.xml
+++ b/comptoir-thorntail/pom.xml
@@ -17,13 +17,13 @@
         <version.mariadb>2.4.2</version.mariadb>
         <thorntail.uber.skip>true</thorntail.uber.skip>
         <!--Filtered in the thorntail configuration yaml -->
-        <gestemps.datasource.connection.url>jdbc:mariadb://localhost:22307/comptoir</gestemps.datasource.connection.url>
-        <gestemps.datasource.connection.user/>
-        <gestemps.datasource.connection.password/>
-        <gestemps.https.keytore.path/>
-        <gestemps.https.keytore.password/>
-        <gestemps.https.key.alias>comptoir.local</gestemps.https.key.alias>
-        <gestemps.https.key.password/>
+        <comptoir.datasource.connection.url>jdbc:mariadb://localhost:22307/comptoir</comptoir.datasource.connection.url>
+        <comptoir.datasource.connection.user/>
+        <comptoir.datasource.connection.password/>
+        <comptoir.https.keytore.path/>
+        <comptoir.https.keytore.password/>
+        <comptoir.https.key.alias>comptoir.local</comptoir.https.key.alias>
+        <comptoir.https.key.password/>
     </properties>
 
     <dependencyManagement>
@@ -127,7 +127,7 @@
     </dependencies>
 
     <build>
-        <finalName>comptoir-thorntail</finalName>
+        <finalName>comptoir</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/comptoir-thorntail/src/main/resources/project-defaults.yml
+++ b/comptoir-thorntail/src/main/resources/project-defaults.yml
@@ -3,18 +3,18 @@ thorntail:
     data-sources:
       comptoir:
         driver-name: mariadb
-        connection-url: "${gestemps.datasource.connection.url}"
-        user-name: "${gestemps.datasource.connection.user}"
-        password: "${gestemps.datasource.connection.password}"
+        connection-url: "${comptoir.datasource.connection.url:jdbc:mariadb://db:3306/comptoir?autoReconnect=true&amp;enablePacketDebug=true}"
+        user-name: "${comptoir.datasource.connection.user:root}"
+        password: "${comptoir.datasource.connection.password}"
         jndi-name: 'java:jboss/datasources/comptoir'
         valid-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker
         validate-on-match: true
         background-validation: false
       comptoir-non-jta:
         driver-name: mariadb
-        connection-url: "${gestemps.datasource.connection.url}"
-        user-name: "${gestemps.datasource.connection.user}"
-        password: "${gestemps.datasource.connection.password}"
+        connection-url: "${comptoir.datasource.connection.url:jdbc:mariadb://db:3306/comptoir?autoReconnect=true&amp;enablePacketDebug=true}"
+        user-name: "${comptoir.datasource.connection.user:root}"
+        password: "${comptoir.datasource.connection.password}"
         jta: false
         jndi-name: 'java:jboss/datasources/comptoirNonJta'
         valid-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker
@@ -46,11 +46,11 @@ thorntail:
   https:
     port: 8443
     keystore:
-      path: "${gestemps.https.keytore.path}"
-      password: "${gestemps.https.keytore.password}"
+      path: "${comptoir.https.keytore.path}"
+      password: "${comptoir.https.keytore.password}"
     key:
-      alias: "${gestemps.https.key.alias}"
-      password: "${gestemps.https.key.password}"
+      alias: "${comptoir.https.key.alias}"
+      password: "${comptoir.https.key.password}"
 
   microprofile:
     config:

--- a/comptoir-ws-api/src/main/java/be/valuya/comptoir/ws/rest/api/domain/company/WsPrestashopImportParams.java
+++ b/comptoir-ws-api/src/main/java/be/valuya/comptoir/ws/rest/api/domain/company/WsPrestashopImportParams.java
@@ -1,20 +1,29 @@
 package be.valuya.comptoir.ws.rest.api.domain.company;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- *
  * @author Yannick Majoros <yannick@valuya.be>
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WsPrestashopImportParams {
 
+    @NotNull
+    @NotBlank
     private String driverClassName = "com.mysql.jdbc.Driver";
+    @NotNull
+    @NotBlank
     private String dbUrl;
+    @NotNull
+    @NotBlank
     private String dbUsername;
+    @NotNull
+    @NotBlank
     private String dbPassword;
 
     public String getDriverClassName() {

--- a/comptoir-ws/src/main/java/be/valuya/comptoir/ws/convert/text/FromWsLocaleTextConverter.java
+++ b/comptoir-ws/src/main/java/be/valuya/comptoir/ws/convert/text/FromWsLocaleTextConverter.java
@@ -31,6 +31,7 @@ public class FromWsLocaleTextConverter {
                 .orElseGet(ArrayList::new);
 
         Map<Locale, String> localeTextMap = sourcesTexts.stream()
+                .filter(t -> t.getText() != null)
                 .collect(Collectors.toMap(
                         WsLocaleText::getLocale,
                         WsLocaleText::getText,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.6'
 services:
 
   back:
-    image: comptoir-thorntail
-    command: -jar /comptoir-thorntail.jar -s/configs/comptoirdev/thorntail-local-config.yml
+    build: ./comptoir-thorntail
+    command: -jar /comptoir-thorntail.jar
     environment:
       - THORNTAIL_SWARM_DEBUG_PORT=8787
       - THORNTAIL_HTTPS_ONLY=false
@@ -16,8 +16,7 @@ services:
       - 9990:9990
       - 8787:8787 # debugger
     volumes:
-      - valuya_dev-certs:/certs
-      - valuya_dev-secrets:/configs
+      - valuya-dev_certs:/certs
 
   db:
     image: mariadb:10
@@ -27,7 +26,7 @@ services:
     volumes:
       - db-data:/var/lib/mysql
       - ../res/comptoir.sql:/docker-entrypoint-initdb.d/comptoir.sql
-      - valuya_dev-secrets:/configs
+      - ./.secrets/db-root-password:/configs/comptoirdev/db-root-password
     ports:
       - 22307:3306
 
@@ -39,18 +38,25 @@ services:
     volumes:
       - napo-db-data:/var/lib/mysql
       - ../res/petitnapo.sql:/docker-entrypoint-initdb.d/petitnapo.sql
-      - valuya_dev-secrets:/configs
+      - ./.secrets/napo-db-root-password:/configs/comptoirdev/napo-db-root-password
     networks:
       - napo-db
     ports:
       - 22306:3306
 
+  make_cert:
+    image: docker.valuya.be/openssl:2
+    environment:
+      - KEYSTORE_PASSWORD=password
+      - CERT_CN=comptoir.local
+    command: '/create-certificate.sh'
+    volumes:
+      - valuya-dev_certs:/etc/ssl/selfsigned
+
 volumes:
   db-data: {}
   napo-db-data: {}
-  valuya_dev-certs:
-    external: true
-  valuya_dev-secrets:
+  valuya-dev_certs:
     external: true
 
 

--- a/generate-openapi.sh
+++ b/generate-openapi.sh
@@ -7,19 +7,19 @@ MVN_HOME=/home/cghislai/apps/idea-IU-192.4488.21/plugins/maven/lib/maven3
 #docker-compose up -d comptoir
 
 pushd comptoir-ws-api
-  mvn clean
-  mkdir target
+mvn clean
+mkdir target
 
-  # Plugin should be able to fetch document from url directly (according to doc), but it fails
-  # See https://github.com/OpenAPITools/openapi-generator/issues/2241
-  curl -k -o target/comptoir-openapi-spec.yml https://comptoir.local:8443/openapi || exit 1
+# Plugin should be able to fetch document from url directly (according to doc), but it fails
+# See https://github.com/OpenAPITools/openapi-generator/issues/2241
+curl -k -o target/comptoir-openapi-spec.yml https://comptoir.local:8443/openapi || exit 1
 
-  mvn -Popenapi-codegen  package
+mvn -Popenapi-codegen package
 
-  pushd target/openapi/ts
+pushd target/openapi/ts
 #    sed -i 's#.*angular/http.*##' package.json
 #    sed -i 's#.*typescript.*#    "typescript": "=3.4.5",#' package.json
-    npm install
-    npm run build
-  popd
+npm install
+npm run build
+popd
 popd


### PR DESCRIPTION
thorntail was used in the last sprint for ease of configuration of the container and to get the mp-openapi implementation.
We should probably use a regular wildfly19 now.